### PR TITLE
Add Medidas Ambientales feature and UI

### DIFF
--- a/lib/main.dart
+++ b/lib/main.dart
@@ -5,6 +5,7 @@ import 'package:proyecto_final/screens/about_us/about_us_screen.dart';
 import 'package:proyecto_final/screens/home/home_screen.dart';
 // ignore: depend_on_referenced_packages
 import 'package:flutter_inappwebview/flutter_inappwebview.dart';
+import 'package:proyecto_final/screens/medidas_ambientales_screen/medidas_ambientales_screen.dart';
 
 void main() {
   WidgetsFlutterBinding.ensureInitialized();
@@ -50,7 +51,7 @@ class _MainScreenState extends State<MainScreen> {
   final List<Widget> _pages = [
     HomeScreen(),
     AboutUsScreen(),
-    const Center(child: Text('Acerca')),
+    MedidasAmbientalesScreen(),
   ];
 
   @override
@@ -71,7 +72,10 @@ class _MainScreenState extends State<MainScreen> {
             icon: Icon(Icons.more_sharp),
             label: "Sobre nosotros",
           ),
-          BottomNavigationBarItem(icon: Icon(Icons.people), label: "acerca de"),
+          BottomNavigationBarItem(
+            icon: Icon(Icons.warning),
+            label: "Medidas medio ambientales",
+          ),
         ],
       ),
     );

--- a/lib/models/Medidas_model/medidas_model.dart
+++ b/lib/models/Medidas_model/medidas_model.dart
@@ -1,0 +1,38 @@
+class Medidas {
+  final String id;
+  final String titulo;
+  final String descripcion;
+  final String categoria;
+  final String icono;
+  final String fechaCreacion;
+
+  Medidas({
+    required this.id,
+    required this.titulo,
+    required this.descripcion,
+    required this.categoria,
+    required this.icono,
+    required this.fechaCreacion,
+  });
+
+  factory Medidas.fromJson(Map<String, dynamic> j) => Medidas(
+    id: j['id'] ?? '',
+    titulo: j['titulo'] ?? '',
+    descripcion: j['descripcion'] ?? '',
+    categoria: j['categoria'] ?? '',
+    icono: j['icono'] ?? '',
+    fechaCreacion: j['fecha_creacion'] ?? '',
+  );
+
+  Map<String, dynamic> toJson() => {
+    'id': id,
+    'titulo': titulo,
+    'descripcion': descripcion,
+    'categoria': categoria,
+    'icono': icono,
+    'fecha_creacion': fechaCreacion,
+  };
+
+  @override
+  String toString() => 'Medidas(titulo: $titulo)';
+}

--- a/lib/screens/medidas_ambientales_screen/medidas_ambientales_screen.dart
+++ b/lib/screens/medidas_ambientales_screen/medidas_ambientales_screen.dart
@@ -1,0 +1,20 @@
+import 'package:flutter/material.dart';
+import 'package:proyecto_final/widgets/Lista_widget_api/lista_medidas.dart';
+
+class MedidasAmbientalesScreen extends StatelessWidget {
+  const MedidasAmbientalesScreen({super.key});
+
+  @override
+  Widget build(BuildContext context) {
+    return Scaffold(
+      backgroundColor: Colors.blueGrey,
+      appBar: AppBar(title: Text("Medidas Ambientales.")),
+      body: SafeArea(
+        child: Padding(
+          padding: const EdgeInsets.all(8.0),
+          child: ListaMedidas(),
+        ),
+      ),
+    );
+  }
+}

--- a/lib/widgets/Lista_widget_api/lista_medidas.dart
+++ b/lib/widgets/Lista_widget_api/lista_medidas.dart
@@ -1,0 +1,103 @@
+import 'dart:convert';
+
+import 'package:flutter/material.dart';
+import 'package:http/http.dart' as http;
+
+import 'package:proyecto_final/models/Medidas_model/medidas_model.dart';
+import 'package:proyecto_final/widgets/Texts/custom_text_to_paragraf.dart';
+import 'package:proyecto_final/widgets/Texts/custom_text_to_titles.dart';
+
+Future<List<Medidas>> fetchMedidas() async {
+  final res = await http.get(
+    Uri.parse('https://adamix.net/medioambiente/medidas'),
+  );
+  if (res.statusCode != 200) throw Exception('Error ${res.statusCode}');
+  final List parsed = json.decode(res.body) as List;
+  return parsed.map((e) => Medidas.fromJson(e)).toList();
+}
+
+class ListaMedidas extends StatefulWidget {
+  const ListaMedidas({super.key});
+
+  @override
+  State<ListaMedidas> createState() => _ListaMedidasState();
+}
+
+class _ListaMedidasState extends State<ListaMedidas> {
+  late Future<List<Medidas>> futureMedidas;
+
+  @override
+  void initState() {
+    super.initState();
+
+    futureMedidas = fetchMedidas();
+  }
+
+  Future<void> _refresh() async {
+    setState(() => futureMedidas = fetchMedidas());
+    await futureMedidas;
+  }
+
+  @override
+  Widget build(BuildContext context) {
+    return Scaffold(
+      appBar: AppBar(title: const Text('Medidas')),
+      body: FutureBuilder<List<Medidas>>(
+        future: futureMedidas,
+        builder: (context, snapshot) {
+          if (snapshot.connectionState != ConnectionState.done) {
+            return const Center(child: CircularProgressIndicator());
+          }
+          if (snapshot.hasError) {
+            return Center(child: Text('Error: ${snapshot.error}'));
+          }
+          final items = snapshot.data ?? [];
+          return RefreshIndicator(
+            onRefresh: _refresh,
+            child: ListView.builder(
+              physics: const AlwaysScrollableScrollPhysics(),
+              itemCount: items.length,
+              itemBuilder: (ctx, i) {
+                final m = items[i];
+                return Card(
+                  child: Padding(
+                    padding: const EdgeInsets.all(8.0),
+                    child: ListTile(
+                      leading: Text(m.icono),
+                      title: Text(m.titulo),
+                      subtitle: Text("Categoria ${m.categoria}"),
+                      onTap: () {
+                        _showDetalle(context, m);
+                      },
+                    ),
+                  ),
+                );
+              },
+            ),
+          );
+        },
+      ),
+    );
+  }
+}
+
+void _showDetalle(BuildContext ctx, Medidas m) {
+  showModalBottomSheet(
+    context: ctx,
+    builder: (_) => Container(
+      color: Colors.blueGrey,
+      child: Padding(
+        padding: EdgeInsets.all(100),
+        child: Column(
+          mainAxisSize: MainAxisSize.min,
+          children: [
+            CustomTextToTitles(title: "${m.titulo} ${m.icono}"),
+            SizedBox(height: 20),
+            CustomTextToParagraf(Texto: m.descripcion),
+            CustomTextToParagraf(Texto: m.fechaCreacion),
+          ],
+        ),
+      ),
+    ),
+  );
+}

--- a/lib/widgets/Texts/custom_text_to_paragraf.dart
+++ b/lib/widgets/Texts/custom_text_to_paragraf.dart
@@ -1,8 +1,10 @@
 import 'package:flutter/material.dart';
 
 class CustomTextToParagraf extends StatelessWidget {
+  // ignore: non_constant_identifier_names
   final String Texto;
 
+  // ignore: non_constant_identifier_names
   const CustomTextToParagraf({super.key, required this.Texto});
 
   @override
@@ -10,10 +12,7 @@ class CustomTextToParagraf extends StatelessWidget {
     return Card(
       child: Padding(
         padding: const EdgeInsets.all(8.0),
-        child: Text(
-          "$Texto",
-          style: TextStyle(color: Colors.black, fontSize: 20),
-        ),
+        child: Text(Texto, style: TextStyle(color: Colors.black, fontSize: 20)),
       ),
     );
   }

--- a/lib/widgets/Texts/custom_text_to_titles.dart
+++ b/lib/widgets/Texts/custom_text_to_titles.dart
@@ -12,7 +12,7 @@ class CustomTextToTitles extends StatelessWidget {
         padding: const EdgeInsets.all(8.0),
         child: Center(
           child: Text(
-            "$title",
+            title,
             style: TextStyle(fontSize: 20, color: Colors.white),
           ),
         ),


### PR DESCRIPTION
Introduces a new Medidas model, a Medidas Ambientales screen, and a widget to fetch and display environmental measures from an API. Updates navigation in main.dart to include the new screen and refines custom text widgets for improved usage.



<img width="429" height="794" alt="image" src="https://github.com/user-attachments/assets/fe2406cd-4878-4e3a-b219-02072efba63a" />
