### PR TITLE
Add equipo feature with model, API, and UI

### DIFF
--- a/lib/main.dart
+++ b/lib/main.dart
@@ -1,10 +1,11 @@
 import 'dart:io';
 import 'package:flutter/material.dart';
 import 'package:proyecto_final/screens/about_us/about_us_screen.dart';
+import 'package:proyecto_final/screens/equipo_screen/equipo_screen.dart';
 import 'package:proyecto_final/screens/home/home_screen.dart';
 import 'package:proyecto_final/screens/protected_areas_screens/protected_areas_screen.dart';
 import 'package:proyecto_final/screens/medidas_ambientales_screen/medidas_ambientales_screen.dart';
-import 'package:proyecto_final/screens/normativas_screen.dart';
+import 'package:proyecto_final/screens/normativas_screen/normativas_screen.dart';
 
 void main() {
   WidgetsFlutterBinding.ensureInitialized();
@@ -52,7 +53,8 @@ class _MainScreenState extends State<MainScreen> {
     const AboutUsScreen(),
     const MedidasAmbientalesScreen(),
     const ProtectedAreasScreen(),
-    const NormativasScreen(), // <- nuevo
+    const NormativasScreen(),
+    const EquipoScreen(),
   ];
 
   @override
@@ -77,9 +79,11 @@ class _MainScreenState extends State<MainScreen> {
             icon: Icon(Icons.list),
             label: "Áreas protegidas",
           ),
+          BottomNavigationBarItem(icon: Icon(Icons.gavel), label: "Normativas"),
+
           BottomNavigationBarItem(
-            icon: Icon(Icons.gavel), // 👈 icono para normativas
-            label: "Normativas",
+            icon: Icon(Icons.people_alt),
+            label: "Equipo",
           ),
         ],
       ),

--- a/lib/models/equipo_model/equipo_model.dart
+++ b/lib/models/equipo_model/equipo_model.dart
@@ -1,0 +1,46 @@
+import 'dart:convert';
+
+class EquipoModel {
+  // ignore: non_constant_identifier_names
+  String? id, nombre, cargo, departamento, foto, biografia, fecha_Creacion;
+  int? orden;
+
+  EquipoModel({
+    this.id,
+    this.nombre,
+    this.cargo,
+    this.departamento,
+    this.foto,
+    this.biografia,
+    this.orden,
+    // ignore: non_constant_identifier_names
+    this.fecha_Creacion,
+  });
+
+  factory EquipoModel.forMap(Map<String, dynamic> m) => EquipoModel(
+    id: m['id'],
+    nombre: m['nombre'],
+    cargo: m['cargo'],
+    departamento: m['departamento'],
+    foto: m['foto'],
+    biografia: m['biografia'],
+    orden: (m['orden'] as num?)?.toInt(),
+    fecha_Creacion: m['fecha_creacion'],
+  );
+
+  Map<String, dynamic> toMap() => {
+    'id': id,
+    'nombre': nombre,
+    'cargo': cargo,
+    'departamento': departamento,
+    'foto': foto,
+    'biografia': biografia,
+    'orden': orden,
+    'fecha_creacion': fecha_Creacion,
+  };
+
+  static List<EquipoModel> listFromJson(String body) {
+    final data = json.decode(body) as List;
+    return data.map((e) => EquipoModel.forMap(e)).toList();
+  }
+}

--- a/lib/screens/equipo_screen/equipo_screen.dart
+++ b/lib/screens/equipo_screen/equipo_screen.dart
@@ -1,0 +1,24 @@
+import 'package:flutter/material.dart';
+import 'package:proyecto_final/service/Api/equipo_services_api/equipo_api.dart';
+import 'package:proyecto_final/widgets/Lista_widget_api/lista_equipo.dart';
+import 'package:proyecto_final/widgets/Texts/custom_text_to_titles.dart';
+
+class EquipoScreen extends StatelessWidget {
+  const EquipoScreen({super.key});
+
+  @override
+  Widget build(BuildContext context) {
+    EquipoApi equipoApi = EquipoApi();
+    return Scaffold(
+      appBar: AppBar(title: Text("Lista de integrantes del equipo")),
+      body: Column(
+        children: [
+          CustomTextToTitles(title: "Listado💾"),
+          SizedBox(height: 20),
+          Expanded(child: EquipoList(future: equipoApi.fetchEquipo())),
+          SizedBox(height: 20),
+        ],
+      ),
+    );
+  }
+}

--- a/lib/screens/normativas_screen/normativas_screen.dart
+++ b/lib/screens/normativas_screen/normativas_screen.dart
@@ -1,6 +1,6 @@
 import 'package:flutter/material.dart';
-import '../models/normativa_model.dart';
-import '../service/normativa_service.dart';
+import '../../models/normativa_model.dart';
+import '../../service/normativa_service.dart';
 
 class NormativasScreen extends StatefulWidget {
   const NormativasScreen({super.key});

--- a/lib/service/Api/equipo_services_api/equipo_api.dart
+++ b/lib/service/Api/equipo_services_api/equipo_api.dart
@@ -1,0 +1,14 @@
+import "package:http/http.dart" as http;
+import 'package:proyecto_final/models/equipo_model/equipo_model.dart';
+
+class EquipoApi {
+  Future<List<EquipoModel>> fetchEquipo() async {
+    final url = Uri.parse('https://adamix.net/medioambiente/equipo');
+    final res = await http.get(url);
+    if (res.statusCode != 200) {
+      // ignore: avoid_print
+      print("error al buscar informacion del equipo ${res.statusCode}");
+    }
+    return EquipoModel.listFromJson(res.body);
+  }
+}

--- a/lib/widgets/Lista_widget_api/lista_equipo.dart
+++ b/lib/widgets/Lista_widget_api/lista_equipo.dart
@@ -1,0 +1,62 @@
+import 'package:flutter/material.dart';
+import 'package:proyecto_final/models/equipo_model/equipo_model.dart';
+
+class EquipoList extends StatelessWidget {
+  final Future<List<EquipoModel>> future;
+  const EquipoList({super.key, required this.future});
+
+  @override
+  Widget build(BuildContext context) {
+    return FutureBuilder<List<EquipoModel>>(
+      future: future,
+      builder: (context, s) {
+        if (s.connectionState == ConnectionState.waiting) {
+          return const Center(child: CircularProgressIndicator());
+        }
+        if (s.hasError) return Center(child: Text('Error: ${s.error}'));
+        final items = s.data ?? [];
+        if (items.isEmpty) return const Center(child: Text('Sin datos'));
+        return ListView.separated(
+          itemCount: items.length,
+          separatorBuilder: (_, __) => const Divider(height: 0),
+          itemBuilder: (context, i) {
+            final e = items[i];
+            return Card(
+              elevation: 4,
+              child: ListTile(
+                leading: (e.foto != null)
+                    ? CircleAvatar(backgroundImage: NetworkImage(e.foto!))
+                    : const CircleAvatar(child: Icon(Icons.person)),
+                title: Text(e.nombre ?? '—'),
+                subtitle: Text('${e.cargo ?? ''}\n${e.departamento ?? ''}'),
+                isThreeLine: true,
+                onTap: () {
+                  showModalBottomSheet(
+                    context: context,
+                    showDragHandle: true,
+                    builder: (_) => Padding(
+                      padding: const EdgeInsets.all(16),
+                      child: SingleChildScrollView(
+                        child: Column(
+                          crossAxisAlignment: CrossAxisAlignment.start,
+                          children: [
+                            Text(
+                              e.nombre ?? '—',
+                              style: Theme.of(context).textTheme.titleLarge,
+                            ),
+                            const SizedBox(height: 8),
+                            Text(e.biografia ?? 'Sin biografía'),
+                          ],
+                        ),
+                      ),
+                    ),
+                  );
+                },
+              ),
+            );
+          },
+        );
+      },
+    );
+  }
+}


### PR DESCRIPTION
Introduces the equipo feature, including EquipoModel, API service for fetching equipo data, EquipoScreen for displaying the list, and a widget for rendering equipo members. Updates main.dart to add equipo to navigation and refactors normativas screen path for better organization.



<img width="448" height="810" alt="image" src="https://github.com/user-attachments/assets/7e362e35-8a8f-4bd1-ae40-dd4404a14e46" />
