### PR TITLE
Add 'Acerca de' team screen and avatar widget

### DIFF
--- a/lib/main.dart
+++ b/lib/main.dart
@@ -1,6 +1,7 @@
 import 'dart:io';
 import 'package:flutter/material.dart';
 import 'package:proyecto_final/screens/about_us/about_us_screen.dart';
+import 'package:proyecto_final/screens/acerca_de/acerca_de.dart';
 import 'package:proyecto_final/screens/equipo_screen/equipo_screen.dart';
 import 'package:proyecto_final/screens/home/home_screen.dart';
 import 'package:proyecto_final/screens/protected_areas_screens/protected_areas_screen.dart';
@@ -58,6 +59,7 @@ class _MainScreenState extends State<MainScreen> {
     const EquipoScreen(),
     const VideosPage(),
     const VoluntariadoForm(),
+    const AcercaDeScreen(),
   ];
 
   @override
@@ -95,6 +97,11 @@ class _MainScreenState extends State<MainScreen> {
           BottomNavigationBarItem(
             icon: Icon(Icons.join_full),
             label: "Voluntariado",
+          ),
+
+          BottomNavigationBarItem(
+            icon: Icon(Icons.circle_notifications),
+            label: "Equipo de desarrollo",
           ),
         ],
       ),

--- a/lib/screens/acerca_de/acerca_de.dart
+++ b/lib/screens/acerca_de/acerca_de.dart
@@ -1,0 +1,66 @@
+import 'package:flutter/material.dart';
+import 'package:proyecto_final/widgets/avatar_name/avatar_name.dart';
+
+class AcercaDeScreen extends StatelessWidget {
+  const AcercaDeScreen({super.key});
+
+  @override
+  Widget build(BuildContext context) {
+    return Scaffold(
+      appBar: AppBar(title: Text("Acerca de nuestro equipo de desarrollo")),
+      body: SafeArea(
+        child: SingleChildScrollView(
+          child: Column(
+            children: [
+              AvatarName(
+                nombre: "Wilgrey Ravelo Cruz",
+                foto: "https://i.postimg.cc/66dF3nSm/image.png",
+                matricula: "2023-0611",
+                telefono: "8494061420",
+              ),
+
+              AvatarName(
+                nombre: "Erick Daniel Cuesto Méndez",
+                foto: "https://i.postimg.cc/KjqPz9yT/Mi-Foto-1.jpg",
+                matricula: "2023-0650",
+                telefono: "8098681783",
+              ),
+
+              AvatarName(
+                nombre: "Julio Oniel Batista",
+                foto:
+                    "https://i.postimg.cc/mrH8nGW5/Imagen-de-Whats-App-2025-08-21-a-las-12-31-55-babe453f.jpg",
+                matricula: "2022-2145",
+                telefono: "8294107270",
+              ),
+
+              AvatarName(
+                nombre: "Norkys G. Sanchez",
+                foto:
+                    "https://i.postimg.cc/3wsbrxZh/Imagen-de-Whats-App-2025-08-21-a-las-10-47-22-651dda99.jpg",
+                matricula: "2021-0322",
+                telefono: "8099749584",
+              ),
+
+              AvatarName(
+                nombre: "Jose Angel L. Castillo",
+                foto:
+                    "https://i.postimg.cc/L5TyVBF4/Imagen-de-Whats-App-2025-08-21-a-las-10-46-20-d5211460.jpg",
+                matricula: "2021-0012",
+                telefono: "8094964913",
+              ),
+
+              AvatarName(
+                nombre: "Jean Carlos Castillo",
+                foto:
+                    "https://i.postimg.cc/jS9MvSmf/Imagen-de-Whats-App-2025-08-21-a-las-10-46-00-4a741a10.jpg",
+                matricula: "2023-0665",
+                telefono: "8297490064",
+              ),
+            ],
+          ),
+        ),
+      ),
+    );
+  }
+}

--- a/lib/widgets/avatar_name/avatar_name.dart
+++ b/lib/widgets/avatar_name/avatar_name.dart
@@ -1,0 +1,93 @@
+import 'package:flutter/material.dart';
+import 'package:url_launcher/url_launcher.dart';
+
+class AvatarName extends StatelessWidget {
+  final String nombre, foto, matricula, telefono;
+
+  const AvatarName({
+    super.key,
+    required this.nombre,
+    required this.foto,
+    required this.matricula,
+    required this.telefono,
+  });
+
+  void _abrirTelegram(String numero) async {
+    final url = Uri.parse("https://t.me/$numero");
+    if (await canLaunchUrl(url)) {
+      await launchUrl(url, mode: LaunchMode.externalApplication);
+    }
+  }
+
+  void _realizarLlamada(String numero) async {
+    final url = Uri.parse("tel:$numero");
+    if (await canLaunchUrl(url)) {
+      await launchUrl(url);
+    }
+  }
+
+  @override
+  Widget build(BuildContext context) {
+    return Padding(
+      padding: const EdgeInsets.all(12.0),
+      child: Card(
+        elevation: 6,
+        shape: RoundedRectangleBorder(borderRadius: BorderRadius.circular(15)),
+        child: Padding(
+          padding: const EdgeInsets.all(15.0),
+          child: Row(
+            children: [
+              CircleAvatar(
+                radius: 40,
+                backgroundImage: NetworkImage(foto),
+                backgroundColor: Colors.grey[300],
+              ),
+              const SizedBox(width: 15),
+              Expanded(
+                child: Column(
+                  crossAxisAlignment: CrossAxisAlignment.start,
+                  children: [
+                    Text(nombre, style: TextStyle(fontSize: 18)),
+                    const SizedBox(height: 5),
+                    Text(
+                      "Matrícula: $matricula",
+                      style: const TextStyle(fontSize: 14, color: Colors.grey),
+                    ),
+                    const SizedBox(height: 10),
+                    Row(
+                      children: [
+                        ElevatedButton.icon(
+                          onPressed: () => _abrirTelegram(telefono),
+                          icon: const Icon(Icons.send),
+                          label: const Text("Telegram"),
+                          style: ElevatedButton.styleFrom(
+                            backgroundColor: Colors.blueAccent,
+                            shape: RoundedRectangleBorder(
+                              borderRadius: BorderRadius.circular(12),
+                            ),
+                          ),
+                        ),
+                        const SizedBox(width: 10),
+                        ElevatedButton.icon(
+                          onPressed: () => _realizarLlamada(telefono),
+                          icon: const Icon(Icons.phone),
+                          label: const Text("Llamar"),
+                          style: ElevatedButton.styleFrom(
+                            backgroundColor: Colors.green,
+                            shape: RoundedRectangleBorder(
+                              borderRadius: BorderRadius.circular(12),
+                            ),
+                          ),
+                        ),
+                      ],
+                    ),
+                  ],
+                ),
+              ),
+            ],
+          ),
+        ),
+      ),
+    );
+  }
+}

--- a/linux/flutter/generated_plugin_registrant.cc
+++ b/linux/flutter/generated_plugin_registrant.cc
@@ -7,9 +7,13 @@
 #include "generated_plugin_registrant.h"
 
 #include <file_selector_linux/file_selector_plugin.h>
+#include <url_launcher_linux/url_launcher_plugin.h>
 
 void fl_register_plugins(FlPluginRegistry* registry) {
   g_autoptr(FlPluginRegistrar) file_selector_linux_registrar =
       fl_plugin_registry_get_registrar_for_plugin(registry, "FileSelectorPlugin");
   file_selector_plugin_register_with_registrar(file_selector_linux_registrar);
+  g_autoptr(FlPluginRegistrar) url_launcher_linux_registrar =
+      fl_plugin_registry_get_registrar_for_plugin(registry, "UrlLauncherPlugin");
+  url_launcher_plugin_register_with_registrar(url_launcher_linux_registrar);
 }

--- a/linux/flutter/generated_plugins.cmake
+++ b/linux/flutter/generated_plugins.cmake
@@ -4,6 +4,7 @@
 
 list(APPEND FLUTTER_PLUGIN_LIST
   file_selector_linux
+  url_launcher_linux
 )
 
 list(APPEND FLUTTER_FFI_PLUGIN_LIST

--- a/macos/Flutter/GeneratedPluginRegistrant.swift
+++ b/macos/Flutter/GeneratedPluginRegistrant.swift
@@ -11,6 +11,7 @@ import package_info_plus
 import path_provider_foundation
 import shared_preferences_foundation
 import sqflite_darwin
+import url_launcher_macos
 import video_player_avfoundation
 import wakelock_plus
 
@@ -21,6 +22,7 @@ func RegisterGeneratedPlugins(registry: FlutterPluginRegistry) {
   PathProviderPlugin.register(with: registry.registrar(forPlugin: "PathProviderPlugin"))
   SharedPreferencesPlugin.register(with: registry.registrar(forPlugin: "SharedPreferencesPlugin"))
   SqflitePlugin.register(with: registry.registrar(forPlugin: "SqflitePlugin"))
+  UrlLauncherPlugin.register(with: registry.registrar(forPlugin: "UrlLauncherPlugin"))
   FVPVideoPlayerPlugin.register(with: registry.registrar(forPlugin: "FVPVideoPlayerPlugin"))
   WakelockPlusMacosPlugin.register(with: registry.registrar(forPlugin: "WakelockPlusMacosPlugin"))
 }

--- a/pubspec.lock
+++ b/pubspec.lock
@@ -829,6 +829,70 @@ packages:
       url: "https://pub.dev"
     source: hosted
     version: "0.3.1"
+  url_launcher:
+    dependency: "direct main"
+    description:
+      name: url_launcher
+      sha256: f6a7e5c4835bb4e3026a04793a4199ca2d14c739ec378fdfe23fc8075d0439f8
+      url: "https://pub.dev"
+    source: hosted
+    version: "6.3.2"
+  url_launcher_android:
+    dependency: transitive
+    description:
+      name: url_launcher_android
+      sha256: "0aedad096a85b49df2e4725fa32118f9fa580f3b14af7a2d2221896a02cd5656"
+      url: "https://pub.dev"
+    source: hosted
+    version: "6.3.17"
+  url_launcher_ios:
+    dependency: transitive
+    description:
+      name: url_launcher_ios
+      sha256: d80b3f567a617cb923546034cc94bfe44eb15f989fe670b37f26abdb9d939cb7
+      url: "https://pub.dev"
+    source: hosted
+    version: "6.3.4"
+  url_launcher_linux:
+    dependency: transitive
+    description:
+      name: url_launcher_linux
+      sha256: "4e9ba368772369e3e08f231d2301b4ef72b9ff87c31192ef471b380ef29a4935"
+      url: "https://pub.dev"
+    source: hosted
+    version: "3.2.1"
+  url_launcher_macos:
+    dependency: transitive
+    description:
+      name: url_launcher_macos
+      sha256: c043a77d6600ac9c38300567f33ef12b0ef4f4783a2c1f00231d2b1941fea13f
+      url: "https://pub.dev"
+    source: hosted
+    version: "3.2.3"
+  url_launcher_platform_interface:
+    dependency: transitive
+    description:
+      name: url_launcher_platform_interface
+      sha256: "552f8a1e663569be95a8190206a38187b531910283c3e982193e4f2733f01029"
+      url: "https://pub.dev"
+    source: hosted
+    version: "2.3.2"
+  url_launcher_web:
+    dependency: transitive
+    description:
+      name: url_launcher_web
+      sha256: "4bd2b7b4dc4d4d0b94e5babfffbca8eac1a126c7f3d6ecbc1a11013faa3abba2"
+      url: "https://pub.dev"
+    source: hosted
+    version: "2.4.1"
+  url_launcher_windows:
+    dependency: transitive
+    description:
+      name: url_launcher_windows
+      sha256: "3284b6d2ac454cf34f114e1d3319866fdd1e19cdc329999057e44ffe936cfa77"
+      url: "https://pub.dev"
+    source: hosted
+    version: "3.1.4"
   uuid:
     dependency: transitive
     description:

--- a/pubspec.yaml
+++ b/pubspec.yaml
@@ -24,8 +24,7 @@ dependencies:
   # flutter_inappwebview: ^6.0.0
   chewie: ^1.7.5
   cached_network_image: ^3.4.1
-
-
+  url_launcher: ^6.3.0
 
 dev_dependencies:
   flutter_test:

--- a/windows/flutter/generated_plugin_registrant.cc
+++ b/windows/flutter/generated_plugin_registrant.cc
@@ -8,10 +8,13 @@
 
 #include <file_selector_windows/file_selector_windows.h>
 #include <flutter_inappwebview_windows/flutter_inappwebview_windows_plugin_c_api.h>
+#include <url_launcher_windows/url_launcher_windows.h>
 
 void RegisterPlugins(flutter::PluginRegistry* registry) {
   FileSelectorWindowsRegisterWithRegistrar(
       registry->GetRegistrarForPlugin("FileSelectorWindows"));
   FlutterInappwebviewWindowsPluginCApiRegisterWithRegistrar(
       registry->GetRegistrarForPlugin("FlutterInappwebviewWindowsPluginCApi"));
+  UrlLauncherWindowsRegisterWithRegistrar(
+      registry->GetRegistrarForPlugin("UrlLauncherWindows"));
 }

--- a/windows/flutter/generated_plugins.cmake
+++ b/windows/flutter/generated_plugins.cmake
@@ -5,6 +5,7 @@
 list(APPEND FLUTTER_PLUGIN_LIST
   file_selector_windows
   flutter_inappwebview_windows
+  url_launcher_windows
 )
 
 list(APPEND FLUTTER_FFI_PLUGIN_LIST


### PR DESCRIPTION
Introduces a new 'Acerca de' screen displaying team member info using the new AvatarName widget. Integrates the screen into navigation, adds url_launcher dependency, and updates platform plugin registrants for url_launcher support.

<img width="485" height="847" alt="image" src="https://github.com/user-attachments/assets/84acd8d2-0be2-4414-9477-50537c6dd9ef" />
